### PR TITLE
RT 103157 - t/oo-api.t failures under Mac OS

### DIFF
--- a/t/oo-api.t
+++ b/t/oo-api.t
@@ -8,8 +8,8 @@ use Test::More 0.96;
 
 use File::LibMagic;
 
-local $ENV{MAGIC};
-delete $ENV{MAGIC};
+local $ENV{MAGIC};	## no critic (RequireInitializationForLocalVars)
+delete $ENV{MAGIC};	# To initialize and then delete seems silly
 
 {
     my %standard = (
@@ -90,7 +90,7 @@ SKIP:
 }
 
 sub _scrape_file_version {
-    foreach ( `file -v` ) {
+    foreach ( `file -v` ) {	## no critic (ProhibitBacktickOperators)
 	chomp;
 	next
 	    unless m/\Amagic file from (.*)/;

--- a/t/oo-api.t
+++ b/t/oo-api.t
@@ -16,7 +16,11 @@ use File::LibMagic;
             qr/us-ascii/,
         ],
         'foo.c' => [
-            [ 'ASCII C program text', 'C source, ASCII text' ],
+            [
+		'ASCII C program text',
+		'C source, ASCII text',
+		'c program, ASCII text',	# Apple default magic
+	    ],
             'text/x-c',
             qr/us-ascii/,
         ],
@@ -54,7 +58,11 @@ SKIP:
             'us-ascii',
         ],
         'foo.c' => [
-            [ 'ASCII C program text', 'C source, ASCII text' ],
+            [
+		'ASCII C program text',
+		'C source, ASCII text',
+		'c program, ASCII text',	# Apple default magic
+	    ],
             'text/x-c',
             'us-ascii',
         ],


### PR DESCRIPTION
The problem here is that libmagic is not very forthcoming on what the default magic file is, so the test looks in the usual place. Apple has for reasons of their own modified the file command and the underlying magic file, which lives in the usual place. So we need a way to find the default magic file for the copy of libmagic that is actually being linked into File::LibMagic.

This pull request attempts to address this issue. The approach used is two-fold.

The first commit adds Apple's description of a C source file to the test, and under macOS 10.13 High Sierra is sufficient to get the test to pass. The offset errors appearing in earlier versions of macOS (as they style it now) appear to have gone away, and I think were cosmetic anyway.

The second commit scrapes the output of 'file -v' (after deleting $ENV{MAGIC}) to try to get a better idea of what the default magic file is. This is not ideal, and assumes the file command we are running goes with the libmagic we are linking against. But the API that would otherwise be more desirable for this is undocumented, which makes me nervous about using it in production code. The third commit simply tweaks the second in response to some perltidy errors.