### PR TITLE
WIP: Move all MAGIC_* constant names to a new module

### DIFF
--- a/dev-bin/regen-constants.pl
+++ b/dev-bin/regen-constants.pl
@@ -5,25 +5,13 @@ use warnings;
 
 use ExtUtils::Constant;
 
-my @names = (
-    qw(
-        MAGIC_CHECK
-        MAGIC_COMPRESS
-        MAGIC_CONTINUE
-        MAGIC_DEBUG
-        MAGIC_DEVICES
-        MAGIC_ERROR
-        MAGIC_MIME
-        MAGIC_NONE
-        MAGIC_PRESERVE_ATIME
-        MAGIC_RAW
-        MAGIC_SYMLINK
-        )
-);
+use FindBin qw( $Bin );
+use lib "$Bin/../lib";
+use File::LibMagic::Constants qw ( Constants );
 
 ExtUtils::Constant::WriteConstants(
     NAME         => 'File::LibMagic',
-    NAMES        => \@names,
+    NAMES        => Constants(),
     DEFAULT_TYPE => 'IV',
     C_FILE       => 'const/inc.c',
     XS_FILE      => 'const/inc.xs',

--- a/inc/MyMakeMaker.pm
+++ b/inc/MyMakeMaker.pm
@@ -18,8 +18,11 @@ override _build_WriteMakefile_args => sub {
 
     my $args = super();
 
-    $args->{PM}
-        = { 'lib/File/LibMagic.pm' => '$(INST_LIB)/File/LibMagic.pm' };
+    $args->{PM} = {
+        'lib/File/LibMagic.pm' => '$(INST_LIB)/File/LibMagic.pm',
+        'lib/File/LibMagic/Constants.pm' =>
+            '$(INST_LIB)/File/LibMagic/Constants.pm',
+    };
     $args->{LIBS}   = '-lmagic';
     $args->{INC}    = '-I. -Ic';
     $args->{XS}     = { 'lib/File/LibMagic.xs' => 'lib/File/LibMagic.c' };

--- a/lib/File/LibMagic.pm
+++ b/lib/File/LibMagic.pm
@@ -7,6 +7,7 @@ use warnings;
 
 use Carp;
 use Exporter;
+use File::LibMagic::Constants qw ( Constants );
 use Scalar::Util qw( reftype );
 use XSLoader;
 
@@ -16,21 +17,7 @@ XSLoader::load( __PACKAGE__, $VERSION );
 
 use base 'Exporter';
 
-my @Constants = qw(
-    MAGIC_CHECK
-    MAGIC_COMPRESS
-    MAGIC_CONTINUE
-    MAGIC_DEBUG
-    MAGIC_DEVICES
-    MAGIC_ERROR
-    MAGIC_MIME
-    MAGIC_NONE
-    MAGIC_PRESERVE_ATIME
-    MAGIC_RAW
-    MAGIC_SYMLINK
-);
-
-for my $name (@Constants) {
+for my $name ( Constants() ) {
     my ( $error, $value ) = constant($name);
 
     croak "WTF defining $name - $error"
@@ -47,7 +34,7 @@ for my $name (@Constants) {
 our %EXPORT_TAGS = (
     'easy'     => [qw( MagicBuffer MagicFile )],
     'complete' => [
-        @Constants,
+        Constants(),
         qw(
             magic_buffer
             magic_buffer_offset

--- a/lib/File/LibMagic/Constants.pm
+++ b/lib/File/LibMagic/Constants.pm
@@ -1,0 +1,28 @@
+package File::LibMagic::Constants;
+
+use 5.008;
+
+use strict;
+use warnings;
+
+use Exporter;
+
+sub Constants {
+    return qw(
+        MAGIC_CHECK
+        MAGIC_COMPRESS
+        MAGIC_CONTINUE
+        MAGIC_DEBUG
+        MAGIC_DEVICES
+        MAGIC_ERROR
+        MAGIC_MIME
+        MAGIC_NONE
+        MAGIC_PRESERVE_ATIME
+        MAGIC_RAW
+        MAGIC_SYMLINK
+    );
+}
+
+our @EXPORT_OK = (Constants);
+
+1;

--- a/t/lib/Test/Exports.pm
+++ b/t/lib/Test/Exports.pm
@@ -8,6 +8,7 @@ use Test::Fatal;
 use Test::More 0.96;
 
 use Exporter qw( import );
+use File::LibMagic::Constants qw ( Constants );
 
 our @EXPORT_OK = qw( test_complete test_easy );
 
@@ -43,21 +44,7 @@ sub test_complete {
 sub _test_constants {
     my $package = shift;
 
-    my @constants = qw(
-        MAGIC_CHECK
-        MAGIC_COMPRESS
-        MAGIC_CONTINUE
-        MAGIC_DEBUG
-        MAGIC_DEVICES
-        MAGIC_ERROR
-        MAGIC_MIME
-        MAGIC_NONE
-        MAGIC_PRESERVE_ATIME
-        MAGIC_RAW
-        MAGIC_SYMLINK
-    );
-
-    foreach my $const (@constants) {
+    foreach my $const ( Constants() ) {
         ## no critic (Variables::RequireInitializationForLocalVars)
         local $@;
         ## no critic (BuiltinFunctions::ProhibitStringyEval)


### PR DESCRIPTION
Reduces maintainence costs when updating the constants list.

I don't know enough about Perl modules so `dzil test` fails.