### PR TITLE
Improve error handling

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -123,6 +123,8 @@ sub _defines {
             if $ac->check_lib( 'magic', 'magic_version' );
     push @defs, '-DHAVE_MAGIC_SETPARAM'
             if $ac->check_lib( 'magic', 'magic_setparam' );
+    push @defs, '-DHAVE_MAGIC_GETPARAM'
+            if $ac->check_lib( 'magic', 'magic_getparam' );
 
     return q{} unless @defs;
     return q{ } . join q{ }, @defs;

--- a/inc/MyMakeMaker.pm
+++ b/inc/MyMakeMaker.pm
@@ -87,6 +87,8 @@ sub _defines {
             if $ac->check_lib( 'magic', 'magic_version' );
     push @defs, '-DHAVE_MAGIC_SETPARAM'
             if $ac->check_lib( 'magic', 'magic_setparam' );
+    push @defs, '-DHAVE_MAGIC_GETPARAM'
+            if $ac->check_lib( 'magic', 'magic_getparam' );
 
     return q{} unless @defs;
     return q{ } . join q{ }, @defs;

--- a/lib/File/LibMagic.xs
+++ b/lib/File/LibMagic.xs
@@ -209,6 +209,25 @@ IV _magic_setparam(m, param, value)
     OUTPUT:
         RETVAL
 
+IV _magic_getparam(m, param, value)
+    magic_t m
+    int param
+    size_t value
+    PREINIT:
+        int ret;
+    CODE:
+#ifdef HAVE_MAGIC_GETPARAM
+        if ( !m ) {
+            croak( "magic_getparam requires a defined magic handle" );
+        }
+        ret = magic_getparam(m, param, &value);
+        RETVAL = !ret;
+#else
+        croak( "your libmagic library does not provide magic_getparam" );
+#endif
+    OUTPUT:
+        RETVAL
+
 SV *magic_buffer_offset(m, buffer, offset, BuffLen)
     magic_t m
     char *buffer


### PR DESCRIPTION
This depends on the params branch being merged.

I'm not sure if the approach is correct or not as
it doesn't seem to add anything very useful, since:

Errors from magic_setflags are very rare and will
not be triggered by the current codebases.

Errors from magic_setparam only happen when not yet
valid values are in max_future_compat and I'm not sure
if folks will care which values are valid or not.